### PR TITLE
Fix id to keyword matching

### DIFF
--- a/parser/testcase_generator/Uebersetzerbau.g4
+++ b/parser/testcase_generator/Uebersetzerbau.g4
@@ -1,5 +1,6 @@
 grammar Uebersetzerbau;
 
+// this rule is modified to not allow empty programs to generate better testcases
 program: ((funcdef | fundec) ';')+ EOF;
 
 funcdef: fundec stats END;
@@ -26,7 +27,7 @@ cond: (cterm OR)* (NOT)? cterm;
 
 cterm: '(' cond ')' | expr '=' expr | expr '<' expr;
 
-lexpr: ID | term '[' term ']';
+lexpr: ID | term '[' expr ']';
 
 expr: term ('+' term)* | term ('*' term)* | term '-' term;
 
@@ -51,9 +52,10 @@ RETURN: 'return';
 OR: 'or';
 NOT: 'not';
 
+ID: // modified to force longer IDs to not conflict with keywords
+	[a-zA-Z][a-zA-Z_0-9][a-zA-Z_0-9][a-zA-Z_0-9][a-zA-Z_0-9][a-zA-Z_0-9][a-zA-Z_0-9][a-zA-Z_0-9]
+		[a-zA-Z_0-9][a-zA-Z_0-9] [a-zA-Z_0-9]*;
 NUM: [0x]? [0-9]+;
-
-ID: [a-zA-Z][a-zA-Z_0-9]*;
 
 WS: [ \t\n\r\f]+ -> skip;
 COMMENT: '/*' .*? '*/' -> skip;


### PR DESCRIPTION
Modify the grammar of the testcase generator it does not generate id names that correspond to keywords. I also fixed a mistake in the grammar. 

I simply force IDs to be at least 10 characters long, so they cannot conflict. 

Probably not the best solution, but it works. 