### PR TITLE
Add troubleshooting advice to testcase gen readme

### DIFF
--- a/parser/testcase_generator/README.md
+++ b/parser/testcase_generator/README.md
@@ -15,3 +15,27 @@ To generate the testcases, maybe change the values for the number of testcases a
 Then run `make` to generate the testcases.
 
 Every time `make` is run, new testcases are generated and the old are overwritten. To remove the generated testcases, run `make clean`.
+
+### If it doesn't work
+
+If the makefile does not work (e.g. Error 127), make sure the `~/.local/bin` directory is in your PATH. You can do this by running the following command:
+
+```bash
+export PATH=$PATH:~/.local/bin
+```
+
+If it still does not work, try running the commands directly in the `parser/testcase_generator` directory:
+
+```bash
+grammarinator-process Uebersetzerbau.g4 -o . > /dev/null 2> /dev/null
+grammarinator-generate \
+		-r program \
+		-n 100 \
+		-d 25 \
+		-o ../generated_test_%d.0 \
+		-s grammarinator.runtime.serializer.simple_space_serializer \
+		--sys-path . \
+		UebersetzerbauGenerator.UebersetzerbauGenerator
+```
+
+**NOTE: For some reason, the PATH gets modified after the `.bashrc` is loaded, so you can sadly not add it in there.**


### PR DESCRIPTION
The PATH variable on their servers is weird and cannot be set in the .bashrc, so i added troubleshooting steps to the readme of the testcase generator.